### PR TITLE
Change storage to use properly indented json

### DIFF
--- a/lib/kvfs.js
+++ b/lib/kvfs.js
@@ -71,7 +71,7 @@ function set(root, key, value, callback) {
         if(error) {
             return callback(error);
         }
-        fs.writeFile(path.join(root, key), str, function(error) {
+        fs.writeFile(path.join(root, key + ".json"), str, function(error) {
             if(error) {
                 return callback(error);
             }
@@ -104,7 +104,7 @@ function ensureFolderParts(root, folders, callback) {
 }
 
 function get(root, key, callback) {
-    fs.readFile(path.join(root, key), function(error, buffer) {
+    fs.readFile(path.join(root, key + ".json"), function(error, buffer) {
         if(error) {
             return callback(error);
         }

--- a/lib/kvfs.js
+++ b/lib/kvfs.js
@@ -62,7 +62,7 @@ function set(root, key, value, callback) {
     var data = { value: value, last_change: new Date().toISOString() };
     var str;
     try {
-        str = JSON.stringify(data);
+        str = JSON.stringify(data, null, 4);
     }
     catch(e) {
         return callback(e);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kvfs",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "Key-Value store based on the file system",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This will allow for easier inspection during debugging. It will, however, somewhat increase space requirement, but storage is cheap.
